### PR TITLE
Add MOAIAP CLI package for sandbox automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# MyOpenAIAutomationPackage
+
+MyOpenAIAutomationPackage (MOAIAP) est un outil en ligne de commande qui aide à orchestrer des projets dans un dossier sandbox et à exploiter l'API d'OpenAI pour résoudre automatiquement les erreurs de démarrage.
+
+## Installation
+
+```bash
+pip install MyOpenAIAutomationPackage
+```
+
+## Commande principale
+
+Le package expose la commande `MOAIAP` avec plusieurs sous-commandes :
+
+- `MOAIAP config` – Configure les secrets (dossier sandbox, identifiants Git, clefs API, clefs SSH) et les stocke localement dans un fichier chiffré.
+- `MOAIAP create-project` – Crée un projet dans le sandbox en clonant un dépôt Git et en mémorisant les commandes de démarrage associées.
+- `MOAIAP run-project` – Exécute les commandes d'un projet donné et, en cas d'échec, sollicite OpenAI (Codex) pour proposer une correction automatique.
+
+## Développement
+
+Le projet suit une structure basée sur `pyproject.toml` et utilise `setuptools`. Les fichiers sources se trouvent dans `src/my_openai_automation_package/`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "MyOpenAIAutomationPackage"
+version = "0.1.0"
+description = "Automate running OpenAI-assisted fixes on sandboxed projects"
+readme = "README.md"
+authors = [
+  {name = "Automation System"}
+]
+requires-python = ">=3.9"
+dependencies = [
+  "cryptography>=41.0.0",
+  "openai>=1.0.0"
+]
+
+[project.urls]
+Homepage = "https://example.com/MyOpenAIAutomationPackage"
+
+[project.scripts]
+MOAIAP = "my_openai_automation_package.cli:main"

--- a/src/my_openai_automation_package/__init__.py
+++ b/src/my_openai_automation_package/__init__.py
@@ -1,0 +1,5 @@
+"""MyOpenAIAutomationPackage - outils CLI pour piloter des projets sandbox."""
+
+from .cli import main
+
+__all__ = ["main"]

--- a/src/my_openai_automation_package/cli.py
+++ b/src/my_openai_automation_package/cli.py
@@ -1,0 +1,173 @@
+"""Interface en ligne de commande pour MyOpenAIAutomationPackage."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from getpass import getpass
+from pathlib import Path
+from typing import List, Optional
+
+from .config_manager import ConfigData, ConfigManager
+from .project_manager import ProjectManager
+from .runner import ProjectRunner
+
+
+def _resolve_optional_file(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    candidate = Path(value).expanduser()
+    if candidate.exists():
+        return candidate.read_text()
+    return value
+
+
+def _prompt_if_missing(prompt_text: str, secret: bool = False) -> Optional[str]:
+    if secret:
+        value = getpass(prompt_text)
+    else:
+        value = input(prompt_text)
+    return value.strip() or None
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="MOAIAP",
+        description="Automatise la configuration et l'exécution de projets OpenAI dans un sandbox.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    config_parser = subparsers.add_parser("config", help="Configure les secrets chiffrés localement")
+    config_parser.add_argument("--sandbox", help="Chemin du dossier sandbox")
+    config_parser.add_argument("--git-username", help="Nom d'utilisateur Git")
+    config_parser.add_argument("--git-email", help="Adresse e-mail Git")
+    config_parser.add_argument("--git-token", help="Token personnel Git")
+    config_parser.add_argument("--openai-key", help="Clef API OpenAI")
+    config_parser.add_argument("--ssh-private-key", help="Chemin ou contenu de la clef privée SSH")
+    config_parser.add_argument("--ssh-public-key", help="Chemin ou contenu de la clef publique SSH")
+
+    create_parser = subparsers.add_parser("create-project", help="Crée un projet dans le sandbox")
+    create_parser.add_argument("--name", required=True, help="Nom du projet")
+    create_parser.add_argument("--repo", required=True, help="URL du dépôt Git")
+    create_parser.add_argument(
+        "--start-cmd",
+        dest="start_cmds",
+        action="append",
+        help="Commande de démarrage (peut être répétée)",
+    )
+    create_parser.add_argument("--branch", help="Branche Git à cloner")
+
+    run_parser = subparsers.add_parser("run-project", help="Exécute un projet et corrige les erreurs via OpenAI")
+    run_parser.add_argument("name", help="Nom du projet à exécuter")
+    run_parser.add_argument(
+        "--max-attempts",
+        type=int,
+        help="Nombre maximum de tentatives par commande",
+    )
+
+    return parser
+
+
+def handle_config(args: argparse.Namespace, config_manager: ConfigManager) -> None:
+    sandbox = args.sandbox or _prompt_if_missing("Chemin du dossier sandbox: ")
+    if not sandbox:
+        raise ValueError("Le chemin du sandbox est obligatoire.")
+
+    git_username = args.git_username or _prompt_if_missing("Nom d'utilisateur Git (optionnel): ")
+    git_email = args.git_email or _prompt_if_missing("Adresse e-mail Git (optionnel): ")
+    git_token = args.git_token or _prompt_if_missing("Token Git (optionnel): ", secret=True)
+    openai_key = args.openai_key or _prompt_if_missing("Clef API OpenAI (optionnel): ", secret=True)
+
+    ssh_private = _resolve_optional_file(
+        args.ssh_private_key or _prompt_if_missing("Chemin vers la clef privée SSH (optionnel): ")
+    )
+    ssh_public = _resolve_optional_file(
+        args.ssh_public_key or _prompt_if_missing("Chemin vers la clef publique SSH (optionnel): ")
+    )
+
+    password = config_manager.prompt_password(confirm=True)
+    config = ConfigData(
+        sandbox_path=sandbox,
+        git_username=git_username,
+        git_email=git_email,
+        git_token=git_token,
+        openai_api_key=openai_key,
+        ssh_private_key=ssh_private,
+        ssh_public_key=ssh_public,
+    )
+    config_manager.save_config(config, password)
+    print("Configuration sauvegardée avec succès.")
+
+
+def _collect_start_commands(initial: Optional[List[str]]) -> List[str]:
+    commands: List[str] = list(initial or [])
+    while not commands:
+        value = _prompt_if_missing(
+            "Commande de démarrage (laisser vide pour terminer): "
+        )
+        if not value:
+            if commands:
+                break
+            print("Au moins une commande est nécessaire.")
+            continue
+        commands.append(value)
+    return commands
+
+
+def handle_create_project(args: argparse.Namespace, config_manager: ConfigManager) -> None:
+    password = config_manager.prompt_password()
+    config = config_manager.load_config(password)
+    sandbox_path = config.get("sandbox_path")
+    if not sandbox_path:
+        raise ValueError("Le chemin du sandbox n'est pas défini. Configurez-le via `MOAIAP config`.")
+
+    project_manager = ProjectManager(config_manager)
+    sandbox = project_manager.ensure_sandbox(str(sandbox_path))
+    project_dir = sandbox / args.name
+
+    commands = _collect_start_commands(args.start_cmds)
+
+    print(f"Clonage du dépôt {args.repo} vers {project_dir}...")
+    project_manager.clone_repository(args.repo, project_dir, branch=args.branch)
+    project_manager.register_project(
+        args.name,
+        args.repo,
+        commands,
+        metadata={"branch": args.branch},
+    )
+    print(f"Projet '{args.name}' créé avec succès dans le sandbox.")
+
+
+def handle_run_project(args: argparse.Namespace, config_manager: ConfigManager) -> None:
+    password = config_manager.prompt_password()
+    project_manager = ProjectManager(config_manager)
+    runner = ProjectRunner(config_manager, project_manager)
+    runner.run_project(args.name, password, max_attempts=args.max_attempts)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    config_manager = ConfigManager()
+
+    try:
+        if args.command == "config":
+            handle_config(args, config_manager)
+        elif args.command == "create-project":
+            handle_create_project(args, config_manager)
+        elif args.command == "run-project":
+            handle_run_project(args, config_manager)
+        else:  # pragma: no cover - sécurité
+            parser.error("Commande non reconnue.")
+            return 1
+    except KeyboardInterrupt:
+        print("\nOpération annulée par l'utilisateur.")
+        return 1
+    except Exception as exc:
+        print(f"Erreur: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/my_openai_automation_package/config_manager.py
+++ b/src/my_openai_automation_package/config_manager.py
@@ -1,0 +1,128 @@
+"""Gestion de la configuration sécurisée pour MOAIAP."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from dataclasses import dataclass, field
+from getpass import getpass
+from pathlib import Path
+from typing import Dict, Optional
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from cryptography.fernet import Fernet
+
+
+@dataclass
+class ConfigData:
+    """Structure forte pour représenter les données de configuration."""
+
+    sandbox_path: str
+    git_username: Optional[str] = None
+    git_email: Optional[str] = None
+    git_token: Optional[str] = None
+    openai_api_key: Optional[str] = None
+    ssh_private_key: Optional[str] = None
+    ssh_public_key: Optional[str] = None
+    extra: Dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Optional[str]]:
+        data: Dict[str, Optional[str]] = {
+            "sandbox_path": self.sandbox_path,
+            "git_username": self.git_username,
+            "git_email": self.git_email,
+            "git_token": self.git_token,
+            "openai_api_key": self.openai_api_key,
+            "ssh_private_key": self.ssh_private_key,
+            "ssh_public_key": self.ssh_public_key,
+        }
+        data.update(self.extra)
+        return data
+
+
+class ConfigManager:
+    """Gère le stockage chiffré des données de configuration."""
+
+    def __init__(self, config_dir: Optional[Path] = None) -> None:
+        self.config_dir = config_dir or Path.home() / ".moaiap"
+        self.config_file = self.config_dir / "config.enc"
+        self.projects_file = self.config_dir / "projects.json"
+
+    # ------------------------------------------------------------------
+    # Gestion des mots de passe
+    # ------------------------------------------------------------------
+    @staticmethod
+    def prompt_password(confirm: bool = False) -> str:
+        """Demande un mot de passe maître à l'utilisateur."""
+
+        password = getpass("Entrez le mot de passe maître: ")
+        if confirm:
+            confirmation = getpass("Confirmez le mot de passe maître: ")
+            if password != confirmation:
+                raise ValueError("Le mot de passe et sa confirmation ne correspondent pas.")
+        if not password:
+            raise ValueError("Le mot de passe ne peut pas être vide.")
+        return password
+
+    # ------------------------------------------------------------------
+    # Stockage sécurisé
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _derive_key(password: str, salt: bytes) -> bytes:
+        kdf = PBKDF2HMAC(
+            algorithm=hashes.SHA256(),
+            length=32,
+            salt=salt,
+            iterations=480_000,
+        )
+        return base64.urlsafe_b64encode(kdf.derive(password.encode("utf-8")))
+
+    @staticmethod
+    def _encrypt(data: Dict[str, Optional[str]], password: str) -> Dict[str, str]:
+        salt = os.urandom(16)
+        key = ConfigManager._derive_key(password, salt)
+        fernet = Fernet(key)
+        payload = json.dumps(data, ensure_ascii=False).encode("utf-8")
+        encrypted = fernet.encrypt(payload)
+        return {
+            "salt": base64.b64encode(salt).decode("utf-8"),
+            "data": encrypted.decode("utf-8"),
+        }
+
+    @staticmethod
+    def _decrypt(encrypted_payload: Dict[str, str], password: str) -> Dict[str, Optional[str]]:
+        salt = base64.b64decode(encrypted_payload["salt"])
+        key = ConfigManager._derive_key(password, salt)
+        fernet = Fernet(key)
+        decrypted = fernet.decrypt(encrypted_payload["data"].encode("utf-8"))
+        return json.loads(decrypted)
+
+    def config_exists(self) -> bool:
+        return self.config_file.exists()
+
+    def save_config(self, config: ConfigData, password: str) -> None:
+        self.config_dir.mkdir(parents=True, exist_ok=True)
+        payload = self._encrypt(config.to_dict(), password)
+        self.config_file.write_text(json.dumps(payload, indent=2))
+
+    def load_config(self, password: str) -> Dict[str, Optional[str]]:
+        if not self.config_file.exists():
+            raise FileNotFoundError(
+                "Aucun fichier de configuration chiffré trouvé. Lancez `MOAIAP config` d'abord."
+            )
+        encrypted_payload = json.loads(self.config_file.read_text())
+        return self._decrypt(encrypted_payload, password)
+
+    # ------------------------------------------------------------------
+    # Gestion des projets enregistrés
+    # ------------------------------------------------------------------
+    def load_projects(self) -> Dict[str, Dict[str, object]]:
+        if not self.projects_file.exists():
+            return {}
+        return json.loads(self.projects_file.read_text())
+
+    def save_projects(self, projects: Dict[str, Dict[str, object]]) -> None:
+        self.config_dir.mkdir(parents=True, exist_ok=True)
+        self.projects_file.write_text(json.dumps(projects, ensure_ascii=False, indent=2))

--- a/src/my_openai_automation_package/project_manager.py
+++ b/src/my_openai_automation_package/project_manager.py
@@ -1,0 +1,89 @@
+"""Gestion des projets sandbox pour MOAIAP."""
+
+from __future__ import annotations
+
+import datetime as dt
+import subprocess
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from .config_manager import ConfigManager
+
+
+class ProjectManager:
+    """Gère la création et le suivi des projets sandbox."""
+
+    def __init__(self, config_manager: ConfigManager) -> None:
+        self.config_manager = config_manager
+
+    # ------------------------------------------------------------------
+    # Gestion du registre des projets
+    # ------------------------------------------------------------------
+    def _load_projects(self) -> Dict[str, Dict[str, object]]:
+        return self.config_manager.load_projects()
+
+    def _save_projects(self, projects: Dict[str, Dict[str, object]]) -> None:
+        self.config_manager.save_projects(projects)
+
+    def register_project(
+        self,
+        name: str,
+        repo_url: str,
+        commands: Iterable[str],
+        metadata: Optional[Dict[str, object]] = None,
+    ) -> Dict[str, object]:
+        projects = self._load_projects()
+        if name in projects:
+            raise ValueError(f"Le projet '{name}' existe déjà dans le registre.")
+
+        project_info = {
+            "name": name,
+            "repo_url": repo_url,
+            "commands": list(commands),
+            "created_at": dt.datetime.utcnow().isoformat(),
+        }
+        if metadata:
+            project_info.update(metadata)
+
+        projects[name] = project_info
+        self._save_projects(projects)
+        return project_info
+
+    def get_project(self, name: str) -> Dict[str, object]:
+        projects = self._load_projects()
+        if name not in projects:
+            raise KeyError(f"Aucun projet nommé '{name}' n'est enregistré. Utilisez `MOAIAP create-project`. ")
+        return projects[name]
+
+    def list_projects(self) -> List[Dict[str, object]]:
+        projects = self._load_projects()
+        return list(projects.values())
+
+    # ------------------------------------------------------------------
+    # Interaction Git / filesystem
+    # ------------------------------------------------------------------
+    def clone_repository(
+        self,
+        repo_url: str,
+        destination: Path,
+        branch: Optional[str] = None,
+    ) -> None:
+        if destination.exists():
+            raise FileExistsError(
+                f"Le dossier destination '{destination}' existe déjà. Choisissez un autre nom de projet."
+            )
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        command = ["git", "clone", repo_url, str(destination)]
+        if branch:
+            command.insert(2, "--branch")
+            command.insert(3, branch)
+        process = subprocess.run(command, check=False, capture_output=True, text=True)
+        if process.returncode != 0:
+            raise RuntimeError(
+                "Échec du clonage du dépôt Git:\n" + process.stderr.strip()
+            )
+
+    def ensure_sandbox(self, sandbox_path: str) -> Path:
+        sandbox = Path(sandbox_path).expanduser().resolve()
+        sandbox.mkdir(parents=True, exist_ok=True)
+        return sandbox

--- a/src/my_openai_automation_package/runner.py
+++ b/src/my_openai_automation_package/runner.py
@@ -1,0 +1,224 @@
+"""Exécution des projets et correction automatisée via OpenAI."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import textwrap
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from .config_manager import ConfigManager
+
+
+class OpenAIResponder:
+    """Encapsule l'appel à l'API OpenAI et la mise en forme des requêtes."""
+
+    def __init__(self, api_key: Optional[str], model: str = "gpt-4.1-mini") -> None:
+        self.api_key = api_key
+        self.model = model
+        self._client = None
+        self._init_error: Optional[str] = None
+        if api_key:
+            try:
+                from openai import OpenAI  # type: ignore
+
+                self._client = OpenAI(api_key=api_key)
+            except Exception as exc:  # pragma: no cover - dépend de l'environnement
+                self._init_error = str(exc)
+
+    def is_ready(self) -> bool:
+        return self._client is not None and self._init_error is None
+
+    def explain_unavailable(self) -> str:
+        if not self.api_key:
+            return "Aucune clef API OpenAI n'est configurée."
+        if self._init_error:
+            return f"Impossible d'initialiser le client OpenAI: {self._init_error}"
+        return "Client OpenAI non initialisé pour une raison inconnue."
+
+    def request_fix(
+        self,
+        project_path: Path,
+        command: str,
+        stdout: str,
+        stderr: str,
+    ) -> Optional[Dict[str, object]]:
+        if not self.is_ready():
+            return None
+
+        trimmed_stdout = stdout[-4000:]
+        trimmed_stderr = stderr[-4000:]
+        prompt = textwrap.dedent(
+            f"""
+            You are an autonomous senior software engineer working inside the sandbox directory
+            `{project_path}`. The following command failed: `{command}`.
+
+            stdout (last 4000 chars):
+            {trimmed_stdout}
+
+            stderr (last 4000 chars):
+            {trimmed_stderr}
+
+            Analyse the failure and propose concrete fixes. Respond strictly in JSON with the schema:
+            {{
+              "notes": "Optional explanation",
+              "files": [{{"path": "relative/path.py", "content": "full new file content"}}],
+              "commands": ["optional shell command to run", ...]
+            }}
+
+            Only include files that must be overwritten with the new content. Do not include explanations
+            outside the JSON payload.
+            """
+        ).strip()
+
+        try:  # pragma: no cover - dépend d'un appel réseau
+            response = self._client.responses.create(  # type: ignore[union-attr]
+                model=self.model,
+                input=[
+                    {"role": "system", "content": "You write JSON patches to fix projects."},
+                    {"role": "user", "content": prompt},
+                ],
+                max_output_tokens=1200,
+            )
+        except Exception as exc:  # pragma: no cover
+            self._init_error = str(exc)
+            return None
+
+        text = getattr(response, "output_text", None)
+        if not text:
+            try:
+                text = "".join(
+                    block.text  # type: ignore[attr-defined]
+                    for item in getattr(response, "output", [])
+                    for block in getattr(item, "content", [])
+                    if hasattr(block, "text")
+                )
+            except Exception:  # pragma: no cover - en cas de structure inattendue
+                text = None
+        if not text:
+            return None
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return None
+
+
+class ProjectRunner:
+    """Orchestre l'exécution d'un projet et les demandes de correction."""
+
+    def __init__(self, config_manager: ConfigManager, project_manager, max_fix_loops: int = 3) -> None:
+        self.config_manager = config_manager
+        self.project_manager = project_manager
+        self.max_fix_loops = max_fix_loops
+
+    def _apply_file_patch(self, project_path: Path, file_info: Dict[str, str]) -> None:
+        relative_path = Path(file_info["path"])
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            raise ValueError(f"Chemin de fichier non sûr reçu: {relative_path}")
+        target_path = project_path / relative_path
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_text(file_info["content"], encoding="utf-8")
+
+    def _run_shell_command(self, command: str, cwd: Path) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            command,
+            shell=True,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+
+    def _attempt_fix(
+        self,
+        responder: OpenAIResponder,
+        project_path: Path,
+        command: str,
+        stdout: str,
+        stderr: str,
+    ) -> bool:
+        fix_payload = responder.request_fix(project_path, command, stdout, stderr)
+        if not fix_payload:
+            return False
+
+        files: Iterable[Dict[str, str]] = fix_payload.get("files", [])  # type: ignore[assignment]
+        for file_info in files:
+            try:
+                self._apply_file_patch(project_path, file_info)
+            except Exception as exc:
+                print(f"Impossible d'appliquer la modification proposée: {exc}")
+                return False
+
+        for extra_command in fix_payload.get("commands", []):  # type: ignore[assignment]
+            if not isinstance(extra_command, str):
+                continue
+            print(f"Exécution de la commande suggérée: {extra_command}")
+            result = self._run_shell_command(extra_command, project_path)
+            if result.returncode != 0:
+                print("La commande suggérée a échoué:")
+                print(result.stdout)
+                print(result.stderr)
+                return False
+
+        notes = fix_payload.get("notes")
+        if notes:
+            print("Notes Codex:", notes)
+        return True
+
+    def run_project(self, project_name: str, password: str, max_attempts: Optional[int] = None) -> None:
+        config = self.config_manager.load_config(password)
+        sandbox_path = config.get("sandbox_path")
+        if not sandbox_path:
+            raise ValueError("Le chemin du sandbox n'est pas défini dans la configuration.")
+
+        project_info = self.project_manager.get_project(project_name)
+        raw_commands = project_info.get("commands", [])  # type: ignore[assignment]
+        commands: List[str] = [str(cmd) for cmd in raw_commands]
+        if not commands:
+            raise ValueError("Aucune commande de démarrage n'est associée à ce projet.")
+
+        project_path = Path(sandbox_path).expanduser().resolve() / project_name
+        if not project_path.exists():
+            raise FileNotFoundError(
+                f"Le dossier du projet '{project_name}' est introuvable dans le sandbox."
+            )
+        responder = OpenAIResponder(config.get("openai_api_key"))
+        attempts_limit = max_attempts or self.max_fix_loops
+
+        for command in commands:
+            attempt = 0
+            while attempt < attempts_limit:
+                attempt += 1
+                print(f"[MOAIAP] Exécution de '{command}' (tentative {attempt}/{attempts_limit})")
+                result = self._run_shell_command(command, project_path)
+                if result.returncode == 0:
+                    print(f"[MOAIAP] Commande '{command}' terminée avec succès.")
+                    break
+
+                print("[MOAIAP] La commande a échoué. Sortie :")
+                print(result.stdout)
+                print(result.stderr)
+
+                if responder.is_ready():
+                    print("[MOAIAP] Demande d'une correction automatique à OpenAI...")
+                    success = self._attempt_fix(
+                        responder,
+                        project_path,
+                        command,
+                        result.stdout,
+                        result.stderr,
+                    )
+                    if not success:
+                        print("[MOAIAP] Impossible d'appliquer automatiquement la correction proposée.")
+                        if attempt >= attempts_limit:
+                            raise RuntimeError(
+                                "La commande échoue malgré les tentatives automatiques."
+                            )
+                        continue
+                else:
+                    print("[MOAIAP]", responder.explain_unavailable())
+                    raise RuntimeError("Impossible de corriger automatiquement l'erreur.")
+            else:
+                raise RuntimeError(
+                    f"Nombre maximum de tentatives atteint pour la commande '{command}'."
+                )


### PR DESCRIPTION
## Summary
- add a pyproject-based package skeleton for MyOpenAIAutomationPackage with MOAIAP entry point
- implement secure configuration storage with encrypted secrets and project registry helpers
- create CLI commands to configure settings, clone sandbox projects, and run them with OpenAI-driven auto-fixes

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d051e4a70c8331aa4a7a55f31b9262